### PR TITLE
Add support for array in local.php.epp

### DIFF
--- a/templates/local.php.epp
+++ b/templates/local.php.epp
@@ -12,11 +12,19 @@ $conf['superuser'] = '<%= $dokuwiki::superuser %>';
 $conf['disableactions'] = '<%= $dokuwiki::disableactions %>';
 <%- } -%>
 $conf['userewrite'] = <%= $dokuwiki::userewrite %>;
-<%- $dokuwiki::custom_config.each |String $key, Variant[String, Integer] $value| { %>
-  <%- if is_string($value) { $sep = "'" } else { $sep = '' } -%>
-  <%- if '.' in $key { -%>
-$conf<%- split($key, '[.]').each |String $k| { %>['<%= $k -%>']<% } %> = <%= "${sep}${value}${sep}" -%>;
+<%- $dokuwiki::custom_config.each |String $key, Variant[String, Integer, Array] $value| { %>
+  <%- if is_array($value) { -%>
+    <%- if '.' in $key { -%>
+$conf<%- split($key, '[.]').each |String $k| { %>['<%= $k -%>']<% } %> = array( '<%= $value.join("', '") -%>' );
+    <%- } else { -%>
+$conf['<%= $key %>'] = array( '<%= $value.join("', '") -%>' );
+    <%- } -%>
   <%- } else { -%>
+    <%- if is_string($value) { $sep = "'" } else { $sep = '' } -%>
+    <%- if '.' in $key { -%>
+$conf<%- split($key, '[.]').each |String $k| { %>['<%= $k -%>']<% } %> = <%= "${sep}${value}${sep}" -%>;
+    <%- } else { -%>
 $conf['<%= $key %>'] = '<%= $value -%>';
+    <%- } -%>
   <%- } -%>
 <%- } -%>


### PR DESCRIPTION
To satify authldap configuration I've add the possibility to manage array in custom_config example

hash
plugin.authldap.attributes:
  - uid
  - cn
  - gecos

generate

$conf['plugin']['authldap']['attributes'] = array( 'uid', 'cn', 'gecos');
